### PR TITLE
Allow host and srflx ICE candidates

### DIFF
--- a/src/webrtc_receiver.cpp
+++ b/src/webrtc_receiver.cpp
@@ -54,14 +54,7 @@ static std::string sanitize_sdp_for_browser(const char* sdp_in) {
             if (low.find(" tcp ") != std::string::npos || low.find("\ttcp ") != std::string::npos || low.find(" tcptype ") != std::string::npos) {
                 continue;
             }
-            // srflx 후보 제거 (브라우저 파서 에러 회피용)
-            if (low.find(" typ srflx") != std::string::npos) {
-                continue;
-            }
-            // host 후보 제거 (GStreamer webrtcbin이 일부 host 후보 처리시 문제 발생)
-            if (low.find(" typ host") != std::string::npos) {
-                continue;
-            }
+            // 이전에는 srflx/host 후보를 제거했으나, 모든 ICE 후보를 전달하기 위해 유지합니다.
             // IPv6 주소 후보 제거 (일부 브라우저/환경에서 파서 민감)
             std::vector<std::string> tokens;
             {

--- a/web/sender.html
+++ b/web/sender.html
@@ -99,15 +99,11 @@
         if (/^a=end-of-candidates\b/.test(t)) return false;
 
         // --- 알려진 문제 라인 필터링 ---
-        // 핵심 문제 라인인 host 후보 제거
-        if (/^a=candidate:/i.test(t) && /\btyp\s+host\b/i.test(t)) return false;
-        // 2차 문제 가능성이 있었던 라인 제거
         if (/^a=rtcp-mux-only/.test(t)) return false;
 
         // 기타 표준 호환성 필터
         if (/^a=candidate:/i.test(t) && /\btcp\b/i.test(t)) return false;
         if (/^a=candidate:/i.test(t) && /\btcptype\b/i.test(t)) return false;
-        if (/^a=candidate:/i.test(t) && /\btyp\s+srflx\b/i.test(t)) return false;
         if (/^a=candidate:/i.test(t) && /:[0-9a-f]+:/i.test(t)) return false;
         return true;
       });


### PR DESCRIPTION
## Summary
- keep srflx and host ICE candidates when sanitizing SDP on both the C++ receiver and browser sender

## Testing
- `cmake -S . -B out`
- `cmake --build out`
- `./out/webrtc_receiver` *(fails: could not connect to display)*

------
https://chatgpt.com/codex/tasks/task_e_68b1878d62708322ad3f78d37dab77d8