### PR TITLE
Use g_main_context_invoke for WebRTC answer handling

### DIFF
--- a/src/webrtc_receiver.cpp
+++ b/src/webrtc_receiver.cpp
@@ -305,6 +305,8 @@ static void on_notify_ice_gathering(GObject* obj, GParamSpec* /*pspec*/, gpointe
         g_free(sdp_str);
         gst_webrtc_session_description_free(local_desc);
 
+        GMainContext* ctx = g_main_loop_get_context(g_loop);
+
         std::thread([=]() {
             g_print("Paste the SDP ANSWER from browser, then end with a line: '===== END SDP ====='\n");
             std::string raw_answer = read_sdp_from_stdin();
@@ -314,7 +316,7 @@ static void on_notify_ice_gathering(GObject* obj, GParamSpec* /*pspec*/, gpointe
                 return;
             }
             // Pass the sanitized SDP to the main loop for processing
-            g_idle_add(on_answer_received, g_strdup(answer.c_str()));
+            g_main_context_invoke(ctx, on_answer_received, g_strdup(answer.c_str()));
         }).detach();
     }
 }


### PR DESCRIPTION
## Summary
- Replace g_idle_add with g_main_context_invoke in on_notify_ice_gathering to safely pass SDP answer from a worker thread
- Capture the main loop context before spawning the thread

## Testing
- `rm -rf build && cmake -S . -B build && cmake --build build`

------
https://chatgpt.com/codex/tasks/task_e_68b18ce13afc83228eeab27ea882b1b8