### PR TITLE
Qt 이벤트 루프 초기화 및 타이머 경고 해결

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ pkg_check_modules(GST REQUIRED gstreamer-1.0 gstreamer-app-1.0 gstreamer-webrtc-
 
 # OpenCV (for imshow)
 find_package(OpenCV REQUIRED)
+find_package(Qt5 COMPONENTS Widgets REQUIRED)
 
 add_executable(webrtc_receiver src/webrtc_receiver.cpp)
 
@@ -25,7 +26,7 @@ endforeach()
 # 정적/동적 링크 라이브러리들
 # modern CMake에선 target_link_libraries에 ${GST_LIBRARIES}를 그대로 넘겨도 동작
 # (플랫폼별 경로가 잡힌 상태)
-target_link_libraries(webrtc_receiver PRIVATE ${GST_LIBRARIES} ${OpenCV_LIBS})
+target_link_libraries(webrtc_receiver PRIVATE ${GST_LIBRARIES} ${OpenCV_LIBS} Qt5::Widgets)
 
 # Windows에서 GStreamer MSI 설치 시 hint가 필요할 수 있음
 # set(CMAKE_PREFIX_PATH "C:/gstreamer/1.0/msvc_x86_64")

--- a/docs/qt_timer_fix.md
+++ b/docs/qt_timer_fix.md
@@ -1,0 +1,18 @@
+# Problem 1-Pager: Qt 이벤트 루프 초기화
+
+## Context
+GStreamer와 OpenCV를 이용해 WebRTC 수신을 수행하며, OpenCV의 `imshow`로 영상을 표시합니다. 실행 시 Qt 타이머 관련 경고가 발생하며 창 표시가 불안정합니다.
+
+## Problem
+OpenCV의 기본 HighGUI가 Qt 이벤트 루프 없이 사용되어 타이머 경고가 출력되고 영상이 제대로 표시되지 않습니다.
+
+## Goal
+- `QApplication`을 사용해 메인 스레드를 Qt가 관리하도록 하고, `cv::startWindowThread()` 호출로 Qt 이벤트 루프를 초기화합니다.
+- CMake에서 Qt 라이브러리를 링크하여 빌드 오류를 방지합니다.
+
+## Non-Goals
+- `main` 함수의 구조 개선이나 다른 모듈의 리팩터링은 이번 범위에 포함되지 않습니다.
+
+## Constraints
+- `main` 함수는 이미 50라인을 초과하지만, 변경 최소화를 위해 별도 리팩터링은 진행하지 않습니다.
+- Qt5 사용을 가정합니다.

--- a/src/webrtc_receiver.cpp
+++ b/src/webrtc_receiver.cpp
@@ -5,6 +5,7 @@
 #include <gst/video/video.h>
 
 #include <opencv2/opencv.hpp>
+#include <QApplication>
 
 #include <iostream>
 #include <string>
@@ -323,6 +324,7 @@ static void on_notify_ice_gathering(GObject* obj, GParamSpec* /*pspec*/, gpointe
 
 int main(int argc, char* argv[]) {
     gst_init(&argc, &argv);
+    QApplication app(argc, argv);
 
     const char* stun = "stun://stun.l.google.com:19302";
     if (argc >= 2) stun = argv[1];
@@ -361,6 +363,7 @@ int main(int argc, char* argv[]) {
     std::thread gst_thread([](){ g_main_loop_run(g_loop); });
 
     cv::namedWindow("WebRTC-Recv", cv::WINDOW_AUTOSIZE);
+    cv::startWindowThread();
     while (g_running.load()) {
         cv::Mat frame;
         {


### PR DESCRIPTION
## 요약
- `QApplication`과 `cv::startWindowThread()`로 Qt 이벤트 루프 초기화
- CMake에 `Qt5::Widgets` 링크 추가
- Qt 타이머 문제에 대한 1-Pager 문서 작성

## 테스트
- `cmake -S . -B build` *(실패: Qt5 패키지 미설치)*
- `sudo apt-get install -y qtbase5-dev` *(실패: 저장소 403 오류)*

------
https://chatgpt.com/codex/tasks/task_e_68b18e0c941c8322ae2b12ac9ae27b1b